### PR TITLE
Update GA library, this should fix the package on Android 12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-analytics:17.0.0'
+    implementation 'com.google.android.gms:play-services-analytics:18.0.1'
 }


### PR DESCRIPTION
On Android 12, this package wouldn't work because of this error. Fix was to update the GA library.

https://stackoverflow.com/questions/68228666/targeting-s-version-10000-and-above-requires-that-one-of-flag-immutable-or-fl